### PR TITLE
fix: fixed one of the two `transactiedatumtijd` field examples in the Productaanvraag Dimpact OpenAPI spec

### DIFF
--- a/community-concepts/productaanvraag/productaanvraag-dimpact.json
+++ b/community-concepts/productaanvraag/productaanvraag-dimpact.json
@@ -322,7 +322,7 @@
         "bedrag" : 19.20,
         "status" : "niet_geslaagd",
         "transactieId" : "123456784",
-        "transactiedatumtijd" : "2021-04-25T21:30:05+00",
+        "transactiedatumtijd" : "2021-04-25T21:30:05.123+00:00",
         "statusCode" : "5",
         "melding" : "Saldo tekort"
       },


### PR DESCRIPTION
Fixed one of the two `transactiedatumtijd` field examples in the Productaanvraag Dimpact OpenAPI spec Productaanvraag Dimpact OpenAPI spec file for consistency and because I think the value was not compliant with the JSON `date-time` type.