### PR TITLE
Update vac-schema.json

### DIFF
--- a/community-concepts/VAC/vac-schema.json
+++ b/community-concepts/VAC/vac-schema.json
@@ -38,7 +38,6 @@
       "items": {
         "type": "object",
         "required": [
-          "afdelingId",
           "afdelingNaam"
         ],
         "properties": {


### PR DESCRIPTION
Removed `afdelingId` as required property for the objects in the array `afdelingen`, to make the objecttype more compatible with existing data.