### PR TITLE
Remove length and format constraints in groepen and afdelingen object types

### DIFF
--- a/community-concepts/Afdeling en Groep/afdeling-schema.json
+++ b/community-concepts/Afdeling en Groep/afdeling-schema.json
@@ -12,8 +12,7 @@
 		"identificatie": {
 			"type": "string",
 			"title": "identificatie",
-			"description": "Een korte identificatie van de afdeling, maximaal 24 tekens.",
-			"maxLength": 24			
+			"description": "Een korte identificatie van de afdeling"	
 		},
 		"naam": {
 			"type": "string",

--- a/community-concepts/Afdeling en Groep/groep-schema.json
+++ b/community-concepts/Afdeling en Groep/groep-schema.json
@@ -13,8 +13,7 @@
 		"identificatie": {
 			"type": "string",
 			"title": "identificatie",
-			"description": "Een korte identificatie van de groep, maximaal 24 tekens.",
-			"maxLength": 24
+			"description": "Een korte identificatie van de groep"
 		},
 		"naam": {
 			"type": "string",
@@ -24,8 +23,7 @@
 		"afdelingId": {
 			"type": "string",
 			"title": "ID van de bovenliggende afdeling.",
-			"description": "ID van de afdeling waar de groep onder valt.",
-			"format": "uuid"
+			"description": "ID van de afdeling waar de groep onder valt."
 		}
 	},
 	"required": [


### PR DESCRIPTION
See this issue on the KISS backlog: https://github.com/Klantinteractie-Servicesysteem/KISS-frontend/issues/969 
This is a non-breaking change: the schema becomes a bit more lenient.