### PR TITLE
Add property email for afdeling and groep object types

### DIFF
--- a/community-concepts/Afdeling en Groep/afdeling-schema.json
+++ b/community-concepts/Afdeling en Groep/afdeling-schema.json
@@ -12,8 +12,7 @@
 		"identificatie": {
 			"type": "string",
 			"title": "identificatie",
-			"description": "Een korte identificatie van de afdeling, maximaal 24 tekens.",
-			"maxLength": 24			
+			"description": "Een korte identificatie van de afdeling"	
 		},
 		"naam": {
 			"type": "string",

--- a/community-concepts/Afdeling en Groep/afdeling-schema.json
+++ b/community-concepts/Afdeling en Groep/afdeling-schema.json
@@ -5,7 +5,8 @@
 	"examples": [
 		{
 			"identificatie": "ondernemen-vergunn002",
-			"naam": "Ondernemen en Vergunningen"
+			"naam": "Ondernemen en Vergunningen",
+			"email": "ondernemen-vergunn002@demodam.nl"
 		}
 	],
 	"properties": {
@@ -18,6 +19,12 @@
 			"type": "string",
 			"title": "Naam van de afdeling",
 			"description": "feitelijke naam van de afdeling"
+		},
+		"email": {
+			"type": "string",
+			"title": "E-mailadres",
+			"format": "email",
+			"description": "E-mailadres van de afdeling"
 		}
 	},
 	"required": [

--- a/community-concepts/Afdeling en Groep/groep-schema.json
+++ b/community-concepts/Afdeling en Groep/groep-schema.json
@@ -13,8 +13,7 @@
 		"identificatie": {
 			"type": "string",
 			"title": "identificatie",
-			"description": "Een korte identificatie van de groep, maximaal 24 tekens.",
-			"maxLength": 24
+			"description": "Een korte identificatie van de groep"
 		},
 		"naam": {
 			"type": "string",
@@ -24,8 +23,7 @@
 		"afdelingId": {
 			"type": "string",
 			"title": "ID van de bovenliggende afdeling.",
-			"description": "ID van de afdeling waar de groep onder valt.",
-			"format": "uuid"
+			"description": "ID van de afdeling waar de groep onder valt."
 		}
 	},
 	"required": [

--- a/community-concepts/Afdeling en Groep/groep-schema.json
+++ b/community-concepts/Afdeling en Groep/groep-schema.json
@@ -6,7 +6,8 @@
 		{
 			"identificatie": "ond-verg-wabo",
 			"naam": "Ondernemen en Vergunningen Wabo",
-			"afdelingId": "12bed5b2-b403-4dc1-96da-1ee9c7a526df"
+			"afdelingId": "12bed5b2-b403-4dc1-96da-1ee9c7a526df",
+			"email": "ond-verg-wabo@demodam.nl"
 		}
 	],
 	"properties": {
@@ -24,6 +25,12 @@
 			"type": "string",
 			"title": "ID van de bovenliggende afdeling.",
 			"description": "ID van de afdeling waar de groep onder valt."
+		},
+		"email": {
+			"type": "string",
+			"title": "E-mailadres",
+			"format": "email",
+			"description": "E-mailadres van de groep"
 		}
 	},
 	"required": [


### PR DESCRIPTION
See this issue on the KISS backlog: https://github.com/Klantinteractie-Servicesysteem/KISS-frontend/issues/818
This is a non-breaking change: the property `email` is not required.

**Note:** this PR builds on (still open) PR https://github.com/open-objecten/objecttypes/pull/28. Keep this in mind regarding the incremental changes, it should only be merged after the parent PR.