### PR TITLE
feat: add support for KVK nummer in the productaanvraag-dimpact.json specification and add field validation for KVK nummer and vestigingsnummer

### DIFF
--- a/community-concepts/productaanvraag/productaanvraag-dimpact.json
+++ b/community-concepts/productaanvraag/productaanvraag-dimpact.json
@@ -355,17 +355,21 @@
           "type" : "string",
           "maxLength" : 9
         },
-        "vestigingsNummer" : {
-          "title" : "Vestigings nummer",
-          "description" : "Korte unieke aanduiding van de Vestiging",
-          "type" : "string",
-          "maxLength" : 24
+        "vestigingsNummer": {
+          "title": "KVK vestigingsnummer",
+          "description": "Korte unieke aanduiding van de vestiging",
+          "type": "string",
+          "minLength": 12,
+          "maxLength": 12,
+          "pattern": "^\\d{12}$"
         },
         "kvkNummer" : {
           "title" : "KVK nummer",
-          "description" : "Unieke identificatie van de onderneming bij de Kamer van Koophandel (KVK).",
+          "description" : "Unieke identificatie van de onderneming bij de Kamer van Koophandel (KVK)",
           "type" : "string",
-          "maxLength" : 8
+          "minLength" : 8,
+          "maxLength" : 8,
+          "pattern": "^\\d{8}$"
         },
         "organisatorischeEenheidIdentificatie" : {
           "title" : "Organisatorische eenheid identificatie",

--- a/community-concepts/productaanvraag/productaanvraag-dimpact.json
+++ b/community-concepts/productaanvraag/productaanvraag-dimpact.json
@@ -441,14 +441,12 @@
         },
         {
           "required" : [
-            "vestigingsNummer",
             "kvkNummer",
             "rolOmschrijvingGeneriek"
           ]
         },
         {
           "required" : [
-            "vestigingsNummer",
             "kvkNummer",
             "roltypeOmschrijving"
           ]

--- a/community-concepts/productaanvraag/productaanvraag-dimpact.json
+++ b/community-concepts/productaanvraag/productaanvraag-dimpact.json
@@ -361,6 +361,12 @@
           "type" : "string",
           "maxLength" : 24
         },
+        "kvkNummer" : {
+          "title" : "KVK nummer",
+          "description" : "Unieke identificatie van de onderneming bij de Kamer van Koophandel (KVK).",
+          "type" : "string",
+          "maxLength" : 8
+        },
         "organisatorischeEenheidIdentificatie" : {
           "title" : "Organisatorische eenheid identificatie",
           "description" : "Korte identificatie van de organisatorische eenheid",
@@ -436,12 +442,14 @@
         {
           "required" : [
             "vestigingsNummer",
+            "kvkNummer",
             "rolOmschrijvingGeneriek"
           ]
         },
         {
           "required" : [
             "vestigingsNummer",
+            "kvkNummer",
             "roltypeOmschrijving"
           ]
         },

--- a/community-concepts/productaanvraag/productaanvraag-dimpact.json
+++ b/community-concepts/productaanvraag/productaanvraag-dimpact.json
@@ -457,6 +457,18 @@
         },
         {
           "required" : [
+            "vestigingsNummer",
+            "rolOmschrijvingGeneriek"
+          ]
+        },
+        {
+          "required" : [
+            "vestigingsNummer",
+            "roltypeOmschrijving"
+          ]
+        },
+        {
+          "required" : [
             "organisatorischeEenheidIdentificatie",
             "rolOmschrijvingGeneriek"
           ]


### PR DESCRIPTION
Added support for a KVK nummer field in the productaanvraag-dimpact.json specification. Both the vestigingsNummer and the kvkNummer need to be provided for productaanvraag - roles identifying a business.

Solves https://dimpact.atlassian.net/browse/PZ-6290