### PR TITLE
`vestigingsnummer` should be optional to `kvk-nummer`

### DIFF
--- a/community-concepts/productaanvraag/productaanvraag-dimpact.json
+++ b/community-concepts/productaanvraag/productaanvraag-dimpact.json
@@ -447,24 +447,18 @@
           "required" : [
             "kvkNummer",
             "rolOmschrijvingGeneriek"
+          ],
+          "optional": [
+            "vestigingsNummer"
           ]
         },
         {
           "required" : [
             "kvkNummer",
             "roltypeOmschrijving"
-          ]
-        },
-        {
-          "required" : [
-            "vestigingsNummer",
-            "rolOmschrijvingGeneriek"
-          ]
-        },
-        {
-          "required" : [
-            "vestigingsNummer",
-            "roltypeOmschrijving"
+          ],
+          "optional": [
+            "vestigingsNummer"
           ]
         },
         {


### PR DESCRIPTION
We only know either a _rechtspersoon_ which only has a `kvk-nummer` or a `vestiging` which has both the `kvk-nummer` and the `vestigingsnummer`