### PR TITLE
Update maximale lengtes groep- en medewerker-ID in Dimpact productaanvraag specificatie

### DIFF
--- a/community-concepts/productaanvraag/productaanvraag-dimpact.json
+++ b/community-concepts/productaanvraag/productaanvraag-dimpact.json
@@ -375,13 +375,13 @@
           "title" : "Organisatorische eenheid identificatie",
           "description" : "Korte identificatie van de organisatorische eenheid",
           "type" : "string",
-          "maxLength" : 24
+          "maxLength" : 255
         },
         "medewerkerIdentificatie" : {
           "title" : "Medewerker identificatie",
           "description" : "Korte unieke aanduiding van de medewerker",
           "type" : "string",
-          "maxLength" : 24
+          "maxLength" : 128
         },
         "rolOmschrijvingGeneriek" : {
           "title" : "Rol omschrijving generiek",


### PR DESCRIPTION
Waarom    

Gemeenten configureren productaanvraagformulieren zodat aangemaakte zaken automatisch aan een groep of medewerker worden toegewezen. OpenZaak heeft de maximale lengte van deze velden al eerder verlengd, maar de Dimpact productaanvraag JSON-schema was hier nooit op aangepast. Hierdoor konden groepsnamen langer dan 24 tekens niet correct worden weggeschreven.

  Wat is er gewijzigd
  In productaanvraag-dimpact.json:
  - organisatorischeEenheidIdentificatie: maxLength 24 → 255
  - medewerkerIdentificatie: maxLength 24 → 128
